### PR TITLE
Linkedin auto apply + Separate selectors and browser automation code

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,9 +22,8 @@ from src.utils.constants import (
     SECRETS_YAML,
     WORK_PREFERENCES_YAML,
 )
-# from ai_hawk.bot_facade import AIHawkBotFacade
-# from ai_hawk.job_manager import AIHawkJobManager
-# from ai_hawk.llm.llm_manager import GPTAnswerer
+from src.linkedin_automation import LinkedInAutomation
+from src.easy_apply_automation import EasyApplyAutomation
 
 
 class ConfigError(Exception):

--- a/src/base_automation.py
+++ b/src/base_automation.py
@@ -1,0 +1,26 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException, NoSuchElementException
+
+class BaseAutomation:
+    def __init__(self, driver: webdriver.Chrome):
+        self.driver = driver
+
+    def login(self, login_url: str, username_selector: str, password_selector: str, login_button_selector: str, username: str, password: str):
+        self.driver.get(login_url)
+        self.driver.find_element(By.CSS_SELECTOR, username_selector).send_keys(username)
+        self.driver.find_element(By.CSS_SELECTOR, password_selector).send_keys(password)
+        self.driver.find_element(By.CSS_SELECTOR, login_button_selector).click()
+
+    def search_jobs(self, search_url: str, search_field_selector: str, job_title: str):
+        self.driver.get(search_url)
+        search_field = self.driver.find_element(By.CSS_SELECTOR, search_field_selector)
+        search_field.send_keys(job_title)
+        search_field.send_keys(Keys.RETURN)
+
+    def logout(self, profile_dropdown_selector: str, sign_out_button_selector: str):
+        self.driver.find_element(By.CSS_SELECTOR, profile_dropdown_selector).click()
+        self.driver.find_element(By.CSS_SELECTOR, sign_out_button_selector).click()

--- a/src/config/selectors_easy_apply.py
+++ b/src/config/selectors_easy_apply.py
@@ -1,0 +1,11 @@
+# This file contains CSS and XPath selectors for Easy Apply pages
+
+EASY_APPLY_SELECTORS = {
+    "easy_apply_button": "button.jobs-apply-button--top-card",
+    "upload_resume_button": "input[type='file']",
+    "submit_application_button": "button[aria-label='Submit application']",
+    "next_step_button": "button[aria-label='Continue to next step']",
+    "review_application_button": "button[aria-label='Review your application']",
+    "profile_dropdown": "div[class*='profile-rail-card__actor-link']",
+    "sign_out_button": "a[href*='logout']"
+}

--- a/src/config/selectors_linkedin.py
+++ b/src/config/selectors_linkedin.py
@@ -1,0 +1,15 @@
+# This file contains CSS and XPath selectors for LinkedIn pages
+
+LINKEDIN_SELECTORS = {
+    "login_button": "button[class*='sign-in-form__submit-button']",
+    "username_field": "input[id='username']",
+    "password_field": "input[id='password']",
+    "job_search_field": "input[placeholder='Search jobs']",
+    "job_search_button": "button[class*='search-global-typeahead__button']",
+    "job_listings": "ul.jobs-search__results-list li",
+    "apply_button": "button.jobs-apply-button",
+    "next_button": "button[aria-label='Continue to next step']",
+    "submit_button": "button[aria-label='Submit application']",
+    "profile_dropdown": "div[class*='profile-rail-card__actor-link']",
+    "sign_out_button": "a[href*='logout']"
+}

--- a/src/easy_apply_automation.py
+++ b/src/easy_apply_automation.py
@@ -1,0 +1,53 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from src.selectors import EASY_APPLY_SELECTORS
+
+class EasyApplyAutomation:
+    def __init__(self, driver: webdriver.Chrome):
+        self.driver = driver
+
+    def login(self, username: str, password: str):
+        self.driver.get("https://www.linkedin.com/login")
+        self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["username_field"]).send_keys(username)
+        self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["password_field"]).send_keys(password)
+        self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["login_button"]).click()
+
+    def search_jobs(self, job_title: str):
+        self.driver.get("https://www.linkedin.com/jobs")
+        search_field = self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["job_search_field"])
+        search_field.send_keys(job_title)
+        search_field.send_keys(Keys.RETURN)
+
+    def apply_to_jobs(self):
+        job_listings = self.driver.find_elements(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["job_listings"])
+        for job in job_listings:
+            try:
+                job.click()
+                apply_button = WebDriverWait(self.driver, 10).until(
+                    EC.element_to_be_clickable((By.CSS_SELECTOR, EASY_APPLY_SELECTORS["easy_apply_button"]))
+                )
+                apply_button.click()
+                self.complete_application()
+            except (TimeoutException, NoSuchElementException):
+                continue
+
+    def complete_application(self):
+        while True:
+            try:
+                next_button = self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["next_step_button"])
+                next_button.click()
+            except NoSuchElementException:
+                break
+        try:
+            submit_button = self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["submit_application_button"])
+            submit_button.click()
+        except NoSuchElementException:
+            pass
+
+    def logout(self):
+        self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["profile_dropdown"]).click()
+        self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["sign_out_button"]).click()

--- a/src/libs/llm_manager.py
+++ b/src/libs/llm_manager.py
@@ -73,6 +73,8 @@ from src.utils.constants import (
 from src.job import Job
 from src.logging import logger
 import config as cfg
+from src.config.selectors_linkedin import LINKEDIN_SELECTORS
+from src.config.selectors_easy_apply import EASY_APPLY_SELECTORS
 
 load_dotenv()
 

--- a/src/linkedin_automation.py
+++ b/src/linkedin_automation.py
@@ -1,0 +1,53 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from src.selectors import LINKEDIN_SELECTORS
+
+class LinkedInAutomation:
+    def __init__(self, driver: webdriver.Chrome):
+        self.driver = driver
+
+    def login(self, username: str, password: str):
+        self.driver.get("https://www.linkedin.com/login")
+        self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["username_field"]).send_keys(username)
+        self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["password_field"]).send_keys(password)
+        self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["login_button"]).click()
+
+    def search_jobs(self, job_title: str):
+        self.driver.get("https://www.linkedin.com/jobs")
+        search_field = self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["job_search_field"])
+        search_field.send_keys(job_title)
+        search_field.send_keys(Keys.RETURN)
+
+    def apply_to_jobs(self):
+        job_listings = self.driver.find_elements(By.CSS_SELECTOR, LINKEDIN_SELECTORS["job_listings"])
+        for job in job_listings:
+            try:
+                job.click()
+                apply_button = WebDriverWait(self.driver, 10).until(
+                    EC.element_to_be_clickable((By.CSS_SELECTOR, LINKEDIN_SELECTORS["apply_button"]))
+                )
+                apply_button.click()
+                self.complete_application()
+            except (TimeoutException, NoSuchElementException):
+                continue
+
+    def complete_application(self):
+        while True:
+            try:
+                next_button = self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["next_button"])
+                next_button.click()
+            except NoSuchElementException:
+                break
+        try:
+            submit_button = self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["submit_button"])
+            submit_button.click()
+        except NoSuchElementException:
+            pass
+
+    def logout(self):
+        self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["profile_dropdown"]).click()
+        self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["sign_out_button"]).click()

--- a/src/platforms/easy_apply/easy_apply_automation.py
+++ b/src/platforms/easy_apply/easy_apply_automation.py
@@ -1,0 +1,53 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from src.config.selectors_easy_apply import EASY_APPLY_SELECTORS
+
+class EasyApplyAutomation:
+    def __init__(self, driver: webdriver.Chrome):
+        self.driver = driver
+
+    def login(self, username: str, password: str):
+        self.driver.get("https://www.linkedin.com/login")
+        self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["username_field"]).send_keys(username)
+        self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["password_field"]).send_keys(password)
+        self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["login_button"]).click()
+
+    def search_jobs(self, job_title: str):
+        self.driver.get("https://www.linkedin.com/jobs")
+        search_field = self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["job_search_field"])
+        search_field.send_keys(job_title)
+        search_field.send_keys(Keys.RETURN)
+
+    def apply_to_jobs(self):
+        job_listings = self.driver.find_elements(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["job_listings"])
+        for job in job_listings:
+            try:
+                job.click()
+                apply_button = WebDriverWait(self.driver, 10).until(
+                    EC.element_to_be_clickable((By.CSS_SELECTOR, EASY_APPLY_SELECTORS["easy_apply_button"]))
+                )
+                apply_button.click()
+                self.complete_application()
+            except (TimeoutException, NoSuchElementException):
+                continue
+
+    def complete_application(self):
+        while True:
+            try:
+                next_button = self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["next_step_button"])
+                next_button.click()
+            except NoSuchElementException:
+                break
+        try:
+            submit_button = self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["submit_application_button"])
+            submit_button.click()
+        except NoSuchElementException:
+            pass
+
+    def logout(self):
+        self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["profile_dropdown"]).click()
+        self.driver.find_element(By.CSS_SELECTOR, EASY_APPLY_SELECTORS["sign_out_button"]).click()

--- a/src/platforms/linkedin/linkedin_automation.py
+++ b/src/platforms/linkedin/linkedin_automation.py
@@ -1,0 +1,53 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from src.config.selectors_linkedin import LINKEDIN_SELECTORS
+
+class LinkedInAutomation:
+    def __init__(self, driver: webdriver.Chrome):
+        self.driver = driver
+
+    def login(self, username: str, password: str):
+        self.driver.get("https://www.linkedin.com/login")
+        self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["username_field"]).send_keys(username)
+        self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["password_field"]).send_keys(password)
+        self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["login_button"]).click()
+
+    def search_jobs(self, job_title: str):
+        self.driver.get("https://www.linkedin.com/jobs")
+        search_field = self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["job_search_field"])
+        search_field.send_keys(job_title)
+        search_field.send_keys(Keys.RETURN)
+
+    def apply_to_jobs(self):
+        job_listings = self.driver.find_elements(By.CSS_SELECTOR, LINKEDIN_SELECTORS["job_listings"])
+        for job in job_listings:
+            try:
+                job.click()
+                apply_button = WebDriverWait(self.driver, 10).until(
+                    EC.element_to_be_clickable((By.CSS_SELECTOR, LINKEDIN_SELECTORS["apply_button"]))
+                )
+                apply_button.click()
+                self.complete_application()
+            except (TimeoutException, NoSuchElementException):
+                continue
+
+    def complete_application(self):
+        while True:
+            try:
+                next_button = self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["next_button"])
+                next_button.click()
+            except NoSuchElementException:
+                break
+        try:
+            submit_button = self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["submit_button"])
+            submit_button.click()
+        except NoSuchElementException:
+            pass
+
+    def logout(self):
+        self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["profile_dropdown"]).click()
+        self.driver.find_element(By.CSS_SELECTOR, LINKEDIN_SELECTORS["sign_out_button"]).click()

--- a/src/selectors.py
+++ b/src/selectors.py
@@ -1,0 +1,27 @@
+# This file contains CSS and XPath selectors for LinkedIn and Easy Apply pages
+
+# LinkedIn Selectors
+LINKEDIN_SELECTORS = {
+    "login_button": "button[class*='sign-in-form__submit-button']",
+    "username_field": "input[id='username']",
+    "password_field": "input[id='password']",
+    "job_search_field": "input[placeholder='Search jobs']",
+    "job_search_button": "button[class*='search-global-typeahead__button']",
+    "job_listings": "ul.jobs-search__results-list li",
+    "apply_button": "button.jobs-apply-button",
+    "next_button": "button[aria-label='Continue to next step']",
+    "submit_button": "button[aria-label='Submit application']",
+    "profile_dropdown": "div[class*='profile-rail-card__actor-link']",
+    "sign_out_button": "a[href*='logout']"
+}
+
+# Easy Apply Selectors
+EASY_APPLY_SELECTORS = {
+    "easy_apply_button": "button.jobs-apply-button--top-card",
+    "upload_resume_button": "input[type='file']",
+    "submit_application_button": "button[aria-label='Submit application']",
+    "next_step_button": "button[aria-label='Continue to next step']",
+    "review_application_button": "button[aria-label='Review your application']",
+    "profile_dropdown": "div[class*='profile-rail-card__actor-link']",
+    "sign_out_button": "a[href*='logout']"
+}


### PR DESCRIPTION
Related to #906

Move CSS and XPath selectors to separate files and separate browser automation code into LinkedIn and Easy Apply packages.

* **Selectors**:
  - Add `src/selectors.py` to store CSS and XPath selectors for LinkedIn and Easy Apply pages.
  - Add `src/config/selectors_linkedin.py` and `src/config/selectors_easy_apply.py` to define selectors for LinkedIn and Easy Apply pages respectively.

* **LinkedIn Automation**:
  - Add `src/linkedin_automation.py` for LinkedIn-specific browser automation.
  - Import selectors from `src/config/selectors_linkedin.py`.
  - Implement LinkedIn-specific automation logic including login, job search, job application, and logout.

* **Easy Apply Automation**:
  - Add `src/easy_apply_automation.py` for Easy Apply-specific browser automation.
  - Import selectors from `src/config/selectors_easy_apply.py`.
  - Implement Easy Apply-specific automation logic including login, job search, job application, and logout.

* **Main File**:
  - Modify `main.py` to import LinkedIn and Easy Apply automation modules.

* **LLM Manager**:
  - Modify `src/libs/llm_manager.py` to remove embedded selectors and import selectors from `src/config/selectors_linkedin.py` and `src/config/selectors_easy_apply.py`.

