### PR TITLE
Replaced wrong repo link and directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ In the digital age, the job search landscape has undergone a dramatic transforma
 3. **Clone the repository:**
 
    ```bash
-   git clone https://github.com/code-infected/Auto_Jobs_Applier_AI_Agent.git
+   git clone https://github.com/feder-cr/Jobs_Applier_AI_Agent.git
    
-   cd Auto_Jobs_Applier_AI_Agent
+   cd Jobs_Applier_AI_Agent
    ```
 
 4. **Activate virtual environment:**


### PR DESCRIPTION
Previously, I mistakenly updated the README with the wrong repository link and directory name. This fixes those errors by providing the correct details.